### PR TITLE
Feature/add metadata hop limit variable

### DIFF
--- a/modules/nomad-cluster/main.tf
+++ b/modules/nomad-cluster/main.tf
@@ -138,9 +138,9 @@ resource "aws_launch_template" "launch_template" {
 
   key_name = var.ssh_key_name
   metadata_options {
-    http_tokens               = "required"   # enforces IMDSv2
-    http_put_response_hop_limit = 1          # 
-    http_endpoint             = "enabled"    # enables the metadata endpoint
+    http_tokens               = "required"                        # enforces IMDSv2
+    http_put_response_hop_limit = var.metadata_hop_limit          # default is 1. increase only as needed for your proxies.
+    http_endpoint             = "enabled"                         # enables the metadata endpoint
   }
 
   iam_instance_profile {

--- a/modules/nomad-cluster/variables.tf
+++ b/modules/nomad-cluster/variables.tf
@@ -287,3 +287,12 @@ variable "enable_iam_setup" {
   type        = bool
   default     = true
 }
+variable "metadata_hop_limit" {
+  description = "no. of network hops allowed to reach the Instance Metadata Service. Default = 1 (most secure; no proxies). Increase only as needed for your proxies. Range: 1–64."
+  type        = number
+  default     = 1
+  validation {
+      condition     = var.metadata_hop_limit >= 1 && var.metadata_hop_limit <= 64
+      error_message = "metadata_hop_limit must be between 1 and 64."
+    }
+}


### PR DESCRIPTION
- adds `metadata_hop_limit` variable (default  1) to EC2 launch template module
- enforces IMDSv2 (`http_tokens = "required"`, `http_endpoint = "enabled"`)
- adds validation to ensure hop limit is between 1 and 64 (as mentioned in [aws docs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-IMDS-existing-instances.html))